### PR TITLE
Bugfix: cannot to post entry

### DIFF
--- a/lib/hatenablog-model.coffee
+++ b/lib/hatenablog-model.coffee
@@ -11,13 +11,13 @@ class HatenaBlog
       @entryBody = ""
 
   getHatenaId: ->
-    atom.config.get("atom-hatenablog.hatenaId")
+    atom.config.get("hatena-blog.hatenaId")
 
   getBlogId: ->
-    atom.config.get("atom-hatenablog.blogId")
+    atom.config.get("hatena-blog.blogId")
 
   getApiToken: ->
-    atom.config.get("atom-hatenablog.apiToken")
+    atom.config.get("hatena-blog.apiToken")
 
   post: (callback) ->
     draftStatus = if @isPublic then 'no' else 'yes'


### PR DESCRIPTION
I could not post a entry to Hatena Blog, so I investigated the cause for this problem.
Then, I discovered that properties are not set on `atom-hatenablog` but `hatena-blog`.

Could you confirm that?
